### PR TITLE
Closes #8: Using (latest) default credentials provider chain and henc…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>com.ixortalk</groupId>
     <artifactId>ixortalk-aws-s3-library</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <name>ixortalk-aws-s3-library</name>
     <description>IxorTalk library for using AWS S3</description>
@@ -38,7 +38,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.14.RELEASE</version>
+        <version>1.5.19.RELEASE</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -46,6 +46,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
+        <aws-java-sdk.version>1.11.526</aws-java-sdk.version>
     </properties>
 
     <organization>
@@ -126,19 +127,6 @@
         </repository>
     </repositories>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-dependencies</artifactId>
-                <version>Dalston.SR5</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -155,12 +143,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.109</version>
+            <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.11.109</version>
+            <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/src/main/java/com/ixortalk/aws/s3/library/config/AwsS3AutoConfiguration.java
+++ b/src/main/java/com/ixortalk/aws/s3/library/config/AwsS3AutoConfiguration.java
@@ -24,12 +24,7 @@
 package com.ixortalk.aws.s3.library.config;
 
 import com.amazonaws.auth.AWSCredentialsProviderChain;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
-import com.amazonaws.auth.InstanceProfileCredentialsProvider;
-import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
-import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.s3.AmazonS3;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -50,13 +45,7 @@ public class AwsS3AutoConfiguration {
 
     @Bean
     public static AWSCredentialsProviderChain awsCredentialsProvider(Environment environment) {
-        return new AWSCredentialsProviderChain(
-                new EnvironmentVariableCredentialsProvider(),
-                new SystemPropertiesCredentialsProvider(),
-                new ProfileCredentialsProvider(),
-                InstanceProfileCredentialsProvider.getInstance(),
-                new AWSStaticCredentialsProvider(new BasicAWSCredentials(environment.getProperty("cloud.aws.credentials.accessKey",""),
-                        environment.getProperty("cloud.aws.credentials.secretKey",""))));
+        return new DefaultAWSCredentialsProviderChain();
     }
 
     @Bean


### PR DESCRIPTION
…e implicitly removing custom properties cloud.aws.credentials.accessKey/cloud.aws.credentials.secretKey in favor of AWS default properties aws.accessKeyId/aws.secretKey